### PR TITLE
Changed default celery routing

### DIFF
--- a/kernelcimonitor/settings/__init__.py
+++ b/kernelcimonitor/settings/__init__.py
@@ -145,6 +145,8 @@ CELERYD_LOG_FORMAT = '[%(asctime)s] %(levelname)s: %(message)s'
 CELERYD_TASK_LOG_FORMAT = '[%(asctime)s] %(levelname)s %(task_name)s: %(message)s'
 CELERY_TIMEZONE = 'UTC'
 CELERY_IMPORTS = ("monitor.tasks", )
+CELERY_QUEUE_NAME = "kernelci"
+CELERY_ROUTES = {"monitor.tasks.*": {"queue": CELERY_QUEUE_NAME}}
 
 KERNELCI_TOKEN="super-secret-token"
 KERNELCI_URL="https://kernelci.org/"


### PR DESCRIPTION
When the worker is deployed on the same host with different worker, they
tend to pick each other's tasks. This patch prevents this problem (to
some extent).

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>