### PR TITLE
Fixed tasks routing to default queue

### DIFF
--- a/kernelcimonitor/settings/__init__.py
+++ b/kernelcimonitor/settings/__init__.py
@@ -145,8 +145,7 @@ CELERYD_LOG_FORMAT = '[%(asctime)s] %(levelname)s: %(message)s'
 CELERYD_TASK_LOG_FORMAT = '[%(asctime)s] %(levelname)s %(task_name)s: %(message)s'
 CELERY_TIMEZONE = 'UTC'
 CELERY_IMPORTS = ("monitor.tasks", )
-CELERY_QUEUE_NAME = "kernelci"
-CELERY_ROUTES = {"monitor.tasks.*": {"queue": CELERY_QUEUE_NAME}}
+CELERY_DEFAULT_QUEUE = 'kernelci'
 
 KERNELCI_TOKEN="super-secret-token"
 KERNELCI_URL="https://kernelci.org/"


### PR DESCRIPTION
Default queue name is now set. This makes all tasks dispatched to proper
queue. Previous routing distionary didn't work.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>