### PR TITLE
tasks: removed hard coded query date_range

### DIFF
--- a/kernelcimonitor/settings/__init__.py
+++ b/kernelcimonitor/settings/__init__.py
@@ -150,7 +150,6 @@ KERNELCI_TOKEN="super-secret-token"
 KERNELCI_URL="https://kernelci.org/"
 KERNELCI_API_URL="https://api.kernelci.org/%s/"
 KERNELCI_STORAGE_URL="https://storage.kernelci.org/"
-KERNELCI_DATE_RANGE=1
 
 LAVA_XMLRPC_URL="https://staging.validation.linaro.org/RPC2/"
 LAVA_USERNAME="lava-user"

--- a/monitor/models.py
+++ b/monitor/models.py
@@ -59,6 +59,12 @@ class Board(models.Model):
         return self.defconfiglist.split()
 
 
+class LastChecked(models.Model):
+    kernelcijob = models.ForeignKey(KernelCIJob)
+    kernelciboard = models.ForeignKey(Board)
+    last_update = models.DateTimeField(auto_now=True)
+
+
 class TestTemplate(models.Model):
     name = models.CharField(max_length=32)
     gitrepo = models.CharField(max_length=1024)


### PR DESCRIPTION
Since frequency of monitor_boots can be set from admin, this change
removes assumption that admin has to be in sync with settings. Last
check on job/board pair is saved to DB. After initial sync which is 24
hours (1440 min) the subsequent syncs depend on the check frequency.
Also time_range was used instead of date_range for better resolution.
Since minimal interval for kernelci is 10 min, shorter checks will be
ignored.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>